### PR TITLE
check for packages before racing starts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # finetune (development version)
 
+* A check was added to make sure that `lme4` or `BradleyTerry2` are installed (#8)
+
 # finetune 0.0.1
 
 * First CRAN release

--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -181,6 +181,8 @@ tune_race_anova_workflow <-
   function(object, resamples, param_info = NULL, grid = 10, metrics = NULL,
            control = control_race()) {
 
+    rlang::check_installed("lme4")
+
     B <- nrow(resamples)
     if (control$randomize) {
       resamples <- randomize_resamples(resamples)

--- a/R/tune_race_win_loss.R
+++ b/R/tune_race_win_loss.R
@@ -191,6 +191,8 @@ tune_race_win_loss_workflow <-
   function(object, resamples, param_info = NULL, grid = 10, metrics = NULL,
            control = control_race()) {
 
+    rlang::check_installed("BradleyTerry2")
+
     B <- nrow(resamples)
     if (control$randomize) {
       resamples <- randomize_resamples(resamples)


### PR DESCRIPTION
Closes #8 

If a package is not installed: 

```r
> remove.packages("BradleyTerry2")
Removing package from ‘/Library/Frameworks/R.framework/Versions/4.0/Resources/library’
(as ‘lib’ is unspecified)

Restarting R session...

> library(finetune)
Loading required package: tune

> example("tune_race_win_loss")

tn_r__> ## No test: 
tn_r__> library(parsnip)

tn_r__> library(rsample)

tn_r__> library(discrim)

tn_r__> library(dials)

tn_r__> ## -----------------------------------------------------------------------------
tn_r__> 
tn_r__> data(two_class_dat, package = "modeldata")

tn_r__> set.seed(6376)

tn_r__> rs <- bootstraps(two_class_dat, times = 10)

tn_r__> ## -----------------------------------------------------------------------------
tn_r__> 
tn_r__> # optimize an regularized discriminant analysis model
tn_r__> rda_spec <-
tn_r__+   discrim_regularized(frac_common_cov = tune(), frac_identity = tune()) %>%
tn_r__+   set_engine("klaR")

tn_r__> ## -----------------------------------------------------------------------------
tn_r__> 
tn_r__> ctrl <- control_race(verbose_elim = TRUE)

tn_r__> set.seed(11)

tn_r__> grid_wl <-
tn_r__+   rda_spec %>%
tn_r__+     tune_race_win_loss(Class ~ ., resamples = rs, grid = 10, control = ctrl)
ℹ The `BradleyTerry2` package is required.
x Would you like to install it?

1: Yes
2: No
```