### PR TITLE
Unfinalized parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fixed bug in `random_integer_neighbor_calc` to keep values inside range (#10)
 
+* `tune_sim_anneal()` now retains a finalized parameter set and replaces any exisitng parameter set that was not finalized (#14)
+
 # finetune 0.0.1
 
 * First CRAN release

--- a/R/racing_helpers.R
+++ b/R/racing_helpers.R
@@ -141,6 +141,7 @@ test_parameters_bt <- function(x, alpha =  0.05) {
   season_schedule <- make_config_pairs(analysis_data)
   # Eliminate pairs with all ties
   season_data <- score_season(season_schedule, analysis_data, maximize)
+
   best_team <- levels(season_data$scoring$player_1)[1]
 
   suppressWarnings(

--- a/R/sim_anneal_helpers.R
+++ b/R/sim_anneal_helpers.R
@@ -362,7 +362,7 @@ color_event <- function(x) {
 
 get_outcome_names <- function(x, rs) {
   preproc <- workflows::pull_workflow_preprocessor(x)
-  if (inherits(preproc, "list")) {
+  if (inherits(preproc, "workflow_variables")) {
     if (any(names(preproc) == "outcomes")) {
       dat <- rs$splits[[1]]$data
       res <- tidyselect::eval_select(preproc$outcomes, data = dat)

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -278,6 +278,7 @@ tune_sim_anneal_workflow <-
     control_init <- control
     control_init$save_workflow <- TRUE
     initial <- tune::check_initial(initial, param_info, object, resamples, metrics, control_init)
+    param_info <- tune::.get_tune_parameters(initial)
 
     y_names <- get_outcome_names(object, resamples)
     # For the above, make changes to tune to get workflow from initial


### PR DESCRIPTION
closes #14 

In cases where a tuning parameters does not have a finalized range (e.g. `mtry`), the initial call to `tune_grid()` that makes the initial results updates the parameter set range.  

This PR fixes this by saving the parameter set after initialization. 