### PR TITLE
Racing shutout errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Imports:
     dials,
     dplyr,
     utils,
+    ranger,
     tidyr,
     tidyselect,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 
 * Fixed bug in `random_integer_neighbor_calc` to keep values inside range (#10)
 
-* `tune_sim_anneal()` now retains a finalized parameter set and replaces any exisitng parameter set that was not finalized (#14)
+* `tune_sim_anneal()` now retains a finalized parameter set and replaces any existing parameter set that was not finalized (#14)
+
+* A bug in win/loss racing was fixed for cases when one tuning parameter had results that were so bad that it broke the Bradley-Terry model (#7)
 
 # finetune 0.0.1
 

--- a/R/racing_helpers.R
+++ b/R/racing_helpers.R
@@ -141,8 +141,13 @@ test_parameters_bt <- function(x, alpha =  0.05) {
   season_schedule <- make_config_pairs(analysis_data)
   # Eliminate pairs with all ties
   season_data <- score_season(season_schedule, analysis_data, maximize)
-  best_team <- levels(season_data$scoring$player_1)[1]
 
+  # Cases, esp with 2 players, where one player doesn't lose any games
+  if (nrow(season_data$scoring) == 0) {
+    return(mercy_rule(season_data, key))
+  }
+
+  best_team <- levels(season_data$scoring$player_1)[1]
   suppressWarnings(
     mod <- BradleyTerry2::BTm(cbind(wins_1, wins_2), player_1, player_2,
                               data = season_data$scoring, br = TRUE)
@@ -162,31 +167,13 @@ test_parameters_bt <- function(x, alpha =  0.05) {
       # a single competition.
       pass = ifelse(upper > 0 & std_err < 500, TRUE, FALSE)
     ) %>%
-    dplyr::bind_rows(
-      tibble::tibble(
-        .config = best_team,
-        value = 0,
-        std_err = 0,
-        lower = 0,
-        upper = 0,
-        pass = TRUE
-      )
-    )
+    dplyr::bind_rows(make_best_results(best_team))
 
 
   ## TODO For both racing methods, make this a function with the configs as
   ## arguments.
   if (length(season_data$eliminated) > 0) {
-    elim_results <-
-      tibble::tibble(
-        .config = season_data$eliminated,
-        value = NA_real_,
-        std_err = NA_real_,
-        lower = NA_real_,
-        upper = NA_real_,
-        pass = FALSE
-      )
-    mod_est <- dplyr::bind_rows(mod_est, elim_results)
+    mod_est <- dplyr::bind_rows(mod_est, make_elim_results(season_data$eliminated))
   }
 
   mod_est <-
@@ -211,6 +198,40 @@ score_match <- function(x, y, maximize) {
   }
 }
 
+make_best_results <- function(player) {
+  tibble::tibble(
+    .config = player,
+    value = 0,
+    std_err = 0,
+    lower = 0,
+    upper = 0,
+    pass = TRUE
+  )
+}
+
+make_elim_results <- function(players) {
+  tibble::tibble(
+    .config = players,
+    value = NA_real_,
+    std_err = NA_real_,
+    lower = NA_real_,
+    upper = NA_real_,
+    pass = FALSE
+  )
+}
+
+mercy_rule <- function(dat, key) {
+  elim <- dat$eliminated
+  lvls <- levels(dat$scoring$player_1)
+  best <- lvls[!(lvls %in% elim)]
+  dplyr::bind_rows(
+    make_best_results(best),
+    make_elim_results(elim)
+  ) %>%
+    dplyr::inner_join(key, by = ".config")
+}
+
+
 score_season <- function(x, dat, maximize = FALSE) {
   # Determine how many matches each team has won. However, if a team loses
   # _all of its games_ (aka getting skunked), do not include it in the BT model
@@ -224,6 +245,7 @@ score_season <- function(x, dat, maximize = FALSE) {
   eliminated <- check_results(dat)
   x <- x %>% dplyr::filter(!(p1 %in% eliminated) & !(p2 %in% eliminated))
   dat <- dat %>% dplyr::filter(!(.config %in% eliminated))
+  current_teams <- unique(dat$.config)
 
   ## -----------------------------------------------------------------------------
 
@@ -263,7 +285,6 @@ score_season <- function(x, dat, maximize = FALSE) {
     dplyr::select(-pair)
 
   # Find overall rankings
-
   player_rankings <-
     dplyr::bind_rows(
       season_results %>% dplyr::select(player = player_1, wins = wins_1),
@@ -299,11 +320,18 @@ score_season <- function(x, dat, maximize = FALSE) {
       dplyr::arrange(dplyr::desc(wins))
   }
 
+  if (nrow(season_results) == 0) {
+    not_elim <- current_teams[!(current_teams %in% eliminated)]
+    lvls <- c(not_elim, eliminated)
+  } else {
+    lvls <- player_rankings$player
+  }
+
   res <-
     season_results %>%
     dplyr::mutate(
-      player_1 = factor(player_1, levels = player_rankings$player),
-      player_2 = factor(player_2, levels = player_rankings$player)
+      player_1 = factor(player_1, levels = lvls),
+      player_2 = factor(player_2, levels = lvls)
     )
   list(scoring = res, eliminated = eliminated)
 }

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -120,6 +120,6 @@ test_that("unfinalized parameters", {
     rf_res_finetune <- wf_rf %>%
       tune_sim_anneal(resamples = bt, initial = rf_res)
   },
-  regex = FALSE
+  regex = NA
   )
 })

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -85,3 +85,41 @@ test_that('variable interface', {
   expect_true(sum(grepl("^initial", collect_metrics(new_new_res)$.config)) == 4)
 
 })
+
+
+test_that("unfinalized parameters", {
+  skip_on_cran()
+  library(workflows)
+  library(rsample)
+  library(parsnip)
+  library(tibble)
+  library(ranger)
+
+  data(two_class_dat, package = "modeldata")
+
+  set.seed(5046)
+  bt <- bootstraps(two_class_dat, times = 5)
+
+  rec_example <- recipe(Class ~ ., data = two_class_dat)
+
+  # RF
+  model_rf <- rand_forest(mtry = tune()) %>%
+    set_mode("classification") %>%
+    set_engine("ranger")
+
+  wf_rf <- workflow() %>%
+    add_model(model_rf) %>%
+    add_recipe(rec_example)
+
+  set.seed(30)
+  rf_res <- wf_rf %>%
+    tune_grid(resamples = bt, grid = 4)
+
+  expect_error({
+    set.seed(40)
+    rf_res_finetune <- wf_rf %>%
+      tune_sim_anneal(resamples = bt, initial = rf_res)
+  },
+  regex = FALSE
+  )
+})

--- a/tests/testthat/test-win-loss-overall.R
+++ b/tests/testthat/test-win-loss-overall.R
@@ -51,3 +51,51 @@ test_that('variable interface', {
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 10)
 })
+
+# ------------------------------------------------------------------------------
+
+test_that('one player is really bad', {
+  skip_on_cran()
+  library(workflows)
+  library(rsample)
+  library(parsnip)
+  library(tibble)
+  library(ranger)
+
+  set.seed(1341)
+  df <- tibble(
+    x1 = rnorm(500, 1:500),
+    x2 = sample(c(1:4), size = 500, replace = T)
+  ) %>%
+    mutate(
+      y = rbinom(500, 1, prob = (x1 / max(x1))) %>% as.factor()
+    )
+
+  set.seed(121)
+  df_folds <- vfold_cv(df, strata = .data$y)
+
+  rf_spec <-
+    rand_forest(min_n = tune(), trees = 10) %>%
+    set_engine('ranger') %>%
+    set_mode("classification")
+
+  wf <- workflow() %>%
+    add_formula(y ~ .) %>%
+    add_model(rf_spec)
+
+  grid <- tibble(min_n = c(1, 400))
+  ctrl <- control_race(burn_in = 2, alpha = .05, randomize = TRUE)
+  expect_error({
+    set.seed(3355)
+    tuning_results <- tune_race_win_loss(
+      wf,
+      resamples = df_folds,
+      metrics = metric_set(roc_auc),
+      grid = grid,
+      control =
+    )
+  },
+  regex = NA,
+  )
+  expect_equal(nrow(show_best(tuning_results)), 1)
+})

--- a/tests/testthat/test-win-loss-overall.R
+++ b/tests/testthat/test-win-loss-overall.R
@@ -56,6 +56,7 @@ test_that('variable interface', {
 
 test_that('one player is really bad', {
   skip_on_cran()
+  skip_if_not_installed("tune", "0.1.5.9001")
   library(workflows)
   library(rsample)
   library(parsnip)
@@ -92,7 +93,7 @@ test_that('one player is really bad', {
       resamples = df_folds,
       metrics = metric_set(roc_auc),
       grid = grid,
-      control =
+      control = ctrl
     )
   },
   regex = NA,


### PR DESCRIPTION
closes #7 

The issue occurred when only two parameter sets were evaluated using win/loss racing and one was worse than the other across all resamples. 

The code was cleaned up a little and, in these cases, we avoid fitting the BT model. 