### PR TITLE
correct `.config` output with `save_pred` in simulated annealing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finetune
 Title: Additional Functions for Model Tuning
-Version: 1.0.1.9000
+Version: 1.0.1.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # finetune (development version)
 
+* Corrects `.config` output with `save_pred = TRUE` in `tune_sim_anneal()`. The function previously outputted a constant `Model1_Preprocessor1` in the `.predictions` slot, and now provides `.config` values that align with those in `.metrics` (#57).
+
 # finetune 1.0.1
 
 * For racing: 

--- a/R/sim_anneal_helpers.R
+++ b/R/sim_anneal_helpers.R
@@ -383,19 +383,33 @@ get_outcome_names <- function(x, rs) {
   res
 }
 
-update_config <- function(x, prefix = NULL, config = "new") {
+update_config <- function(x, prefix = NULL, config = "new", save_pred) {
   if (!is.null(prefix)) {
     x$.metrics <-
       purrr::map(
         x$.metrics,
         ~ dplyr::mutate(.x, .config = paste0(prefix, "_", .config))
       )
+    if (save_pred) {
+      x$.predictions <-
+        purrr::map(
+          x$.predictions,
+          ~ dplyr::mutate(.x, .config = paste0(prefix, "_", .config))
+        )
+    }
   } else {
     x$.metrics <-
       purrr::map(
         x$.metrics,
         ~ dplyr::mutate(.x, .config = config)
       )
+    if (save_pred) {
+      x$.predictions <-
+        purrr::map(
+          x$.predictions,
+          ~ dplyr::mutate(.x, .config = config)
+        )
+    }
   }
   x
 }

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -329,7 +329,7 @@ tune_sim_anneal_workflow <-
         rset_info = rset_info,
         workflow = object
       ) %>%
-      update_config(prefix = "initial")
+      update_config(prefix = "initial", save_pred = control$save_pred)
 
     mean_stats <- tune::estimate_tune_results(unsummarized)
 
@@ -409,7 +409,7 @@ tune_sim_anneal_workflow <-
           control = control_init
         ) %>%
         dplyr::mutate(.iter = i) %>%
-        update_config(config = paste0("Iter", i))
+        update_config(config = paste0("Iter", i), save_pred = control$save_pred)
 
       result_history <-
         result_history %>%


### PR DESCRIPTION
Closes #57!

An updated reprex from the initial issue, with the new version:

``` r
# load libraries ---------------------------------------------------------------
library(tidymodels)
library(finetune)

# setup ------------------------------------------------------------------------
data(ames)
ames$Sale_Price <- log(ames$Sale_Price)

spec <- linear_reg(engine = "glmnet", penalty = tune(), mixture = tune())
form <- Sale_Price ~ .
set.seed(1)
boots <- bootstraps(ames, times = 5)
metrics <- yardstick::metric_set(yardstick::rmse)

# simulated annealing ----------------------------------------------------------
set.seed(1)
res_sim_anneal <-
  tune_sim_anneal(
    object = spec, preproc = form, resamples = boots, metrics = metrics,
    control = control_sim_anneal(save_pred = TRUE, save_workflow = TRUE)
  )
#> Optimizing rmse
#> Initial best: 0.18813
#>  1 ♥ new best           rmse=0.16864 (+/-0.01079)
#>  2 ◯ accept suboptimal  rmse=0.16981 (+/-0.01065)
#>  3 ◯ accept suboptimal  rmse=0.17384 (+/-0.01191)
#>  4 ─ discard suboptimal rmse=0.18508 (+/-0.01052)
#>  5 + better suboptimal  rmse=0.16915 (+/-0.01145)
#>  6 ◯ accept suboptimal  rmse=0.16962 (+/-0.01227)
#>  7 ─ discard suboptimal rmse=0.17377 (+/-0.01203)
#>  8 ─ discard suboptimal rmse=0.18469 (+/-0.007478)
#>  9 ✖ restart from best  rmse=0.17793 (+/-0.01141)
#> 10 ◯ accept suboptimal  rmse=0.16928 (+/-0.01203)

# the `.config` values now align
 collect_predictions(res_sim_anneal) %>% pull(.config) %>% unique()
#>  [1] "initial_Preprocessor1_Model1" "Iter1"                       
#>  [3] "Iter2"                        "Iter3"                       
#>  [5] "Iter4"                        "Iter5"                       
#>  [7] "Iter6"                        "Iter7"                       
#>  [9] "Iter8"                        "Iter9"                       
#> [11] "Iter10"
collect_metrics(res_sim_anneal) %>% pull(.config) %>% unique()
#>  [1] "initial_Preprocessor1_Model1" "Iter1"                       
#>  [3] "Iter2"                        "Iter3"                       
#>  [5] "Iter4"                        "Iter5"                       
#>  [7] "Iter6"                        "Iter7"                       
#>  [9] "Iter8"                        "Iter9"                       
#> [11] "Iter10"
```

<sup>Created on 2022-11-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Will make simulated annealing compatible with stacks, with tests in https://github.com/tidymodels/extratests/pull/59. :)