### PR TITLE
log tuning issues interactively

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finetune
 Title: Additional Functions for Model Tuning
-Version: 1.0.1.9001
+Version: 1.0.1.9002
 Authors@R: c(
     person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),
@@ -19,7 +19,7 @@ URL: https://github.com/tidymodels/finetune,
 BugReports: https://github.com/tidymodels/finetune/issues
 Depends: 
     R (>= 3.4),
-    tune (>= 1.0.1.9001)
+    tune (>= 1.0.1.9002)
 Imports: 
     cli,
     dials (>= 0.1.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1.9000
 Remotes:
-    tidymodels/tune
+    tidymodels/tune#60

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1.9000
 Remotes:
-    tidymodels/tune#60
+    tidymodels/tune#593

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1.9000
 Remotes:
-    tidymodels/tune#593
+    tidymodels/tune

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL: https://github.com/tidymodels/finetune,
 BugReports: https://github.com/tidymodels/finetune/issues
 Depends: 
     R (>= 3.4),
-    tune (>= 1.0.1)
+    tune (>= 1.0.1.9001)
 Imports: 
     cli,
     dials (>= 0.1.0),
@@ -55,3 +55,5 @@ Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1.9000
+Remotes:
+    tidymodels/tune

--- a/R/racing_helpers.R
+++ b/R/racing_helpers.R
@@ -435,7 +435,7 @@ log_racing <- function(control, x, splits, grid_size, metric) {
     tune_cols$message$info(
       paste0(cli::symbol$info, " ", labs, msg)
     )
-  rlang::inform(msg)
+  cli::cli_bullets(msg)
 }
 
 

--- a/R/sim_anneal_helpers.R
+++ b/R/sim_anneal_helpers.R
@@ -334,7 +334,7 @@ log_sa_progress <- function(control = list(verbose_iter = TRUE), x, metric, max_
     msg <- paste0("Initial best: ", sprintf(dig, signif(initial_res, digits = digits)))
   }
 
-  rlang::inform(cols$message$info(msg))
+  cli::cli_bullets(cols$message$info(msg))
 }
 
 format_event <- function(x) {

--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -198,6 +198,8 @@ tune_race_anova_workflow <-
            control = control_race()) {
     rlang::check_installed("lme4")
 
+    tune::initialize_catalog(control = control)
+
     B <- nrow(resamples)
     if (control$randomize) {
       resamples <- randomize_resamples(resamples)

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -282,6 +282,8 @@ tune_sim_anneal_workflow <-
     start_time <- proc.time()[3]
     cols <- tune::get_tune_colors()
 
+    tune::initialize_catalog(control = control)
+
     # ------------------------------------------------------------------------------
     # Check various inputs
 

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -356,7 +356,7 @@ tune_sim_anneal_workflow <-
 
     cols <- tune::get_tune_colors()
     if (control$verbose_iter) {
-      rlang::inform(cols$message$info(paste("Optimizing", metrics_name)))
+      cli::cli_bullets(cols$message$info(paste("Optimizing", metrics_name)))
     }
 
     ## -----------------------------------------------------------------------------

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -241,6 +241,8 @@ tune_sim_anneal.model_spec <- function(object,
     wflow <- workflows::add_formula(wflow, preprocessor)
   }
 
+  tune::initialize_catalog(control = control)
+
   tune_sim_anneal_workflow(
     wflow,
     resamples = resamples, iter = iter,
@@ -265,6 +267,8 @@ tune_sim_anneal.workflow <-
 
     control <- parsnip::condense_control(control, control_sim_anneal())
 
+    tune::initialize_catalog(control = control)
+
     tune_sim_anneal_workflow(
       object,
       resamples = resamples, iter = iter,
@@ -281,8 +285,6 @@ tune_sim_anneal_workflow <-
            initial = 5, control = control_sim_anneal()) {
     start_time <- proc.time()[3]
     cols <- tune::get_tune_colors()
-
-    tune::initialize_catalog(control = control)
 
     # ------------------------------------------------------------------------------
     # Check various inputs

--- a/tests/testthat/_snaps/anova-filter.md
+++ b/tests/testthat/_snaps/anova-filter.md
@@ -3,22 +3,22 @@
     Code
       finetune:::log_racing(control_race(verbose_elim = TRUE), anova_res,
       ames_grid_search$splits, 10, "rmse")
-    Message <rlang_message>
-      i Fold10:  7 eliminated;  3 candidates remain.
+    Message <cliMessage>
+      i Fold10: 7 eliminated; 3 candidates remain.
 
 ---
 
     Code
       finetune:::log_racing(control_race(verbose_elim = TRUE), anova_res,
       ames_grid_search$splits, 10, "rmse")
-    Message <rlang_message>
-      i Fold10:  7 eliminated;  3 candidates remain.
+    Message <cliMessage>
+      i Fold10: 7 eliminated; 3 candidates remain.
 
 ---
 
     Code
       finetune:::log_racing(control_race(verbose_elim = TRUE), anova_res,
       ames_grid_search$splits, 10, "rmse")
-    Message <rlang_message>
-      i Fold10:  7 eliminated;  3 candidates remain.
+    Message <cliMessage>
+      i Fold10: 7 eliminated; 3 candidates remain.
 

--- a/tests/testthat/_snaps/anova-overall.md
+++ b/tests/testthat/_snaps/anova-overall.md
@@ -7,6 +7,7 @@
     Message <rlang_message>
       i Racing will maximize the roc_auc metric.
       i Resamples are analyzed in a random order.
+    Message <cliMessage>
       i Fold3, Repeat1: 2 eliminated; 2 candidates remain.
       i Fold2, Repeat2: All but one parameter combination were eliminated.
 

--- a/tests/testthat/_snaps/sa-misc.md
+++ b/tests/testthat/_snaps/sa-misc.md
@@ -3,46 +3,46 @@
     Code
       set.seed(1)
       f_res_1 <- rda_spec %>% tune_sim_anneal(Class ~ ., rs, iter = 3)
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.85161
-      1 ( ) accept suboptimal  roc_auc=0.84064	(+/-0.01096)
-      2 ( ) accept suboptimal  roc_auc=0.83789	(+/-0.01086)
-      3 ( ) accept suboptimal  roc_auc=0.83261	(+/-0.0109)
+      1 ( ) accept suboptimal roc_auc=0.84064 (+/-0.01096)
+      2 ( ) accept suboptimal roc_auc=0.83789 (+/-0.01086)
+      3 ( ) accept suboptimal roc_auc=0.83261 (+/-0.0109)
 
 ---
 
     Code
       set.seed(1)
       f_res_2 <- rda_spec %>% tune_sim_anneal(Class ~ ., rs, iter = 3, param_info = rda_param)
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.85192
-      1 ( ) accept suboptimal  roc_auc=0.848	(+/-0.01072)
-      2 ( ) accept suboptimal  roc_auc=0.84678	(+/-0.01067)
-      3 ( ) accept suboptimal  roc_auc=0.84534	(+/-0.01097)
+      1 ( ) accept suboptimal roc_auc=0.848 (+/-0.01072)
+      2 ( ) accept suboptimal roc_auc=0.84678 (+/-0.01067)
+      3 ( ) accept suboptimal roc_auc=0.84534 (+/-0.01097)
 
 ---
 
     Code
       set.seed(1)
       f_rec_1 <- rda_spec %>% tune_sim_anneal(rec, rs, iter = 3)
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.87657
-      1 ( ) accept suboptimal  roc_auc=0.87345	(+/-0.008739)
-      2 ( ) accept suboptimal  roc_auc=0.87124	(+/-0.008458)
-      3 ( ) accept suboptimal  roc_auc=0.86909	(+/-0.008582)
+      1 ( ) accept suboptimal roc_auc=0.87345 (+/-0.008739)
+      2 ( ) accept suboptimal roc_auc=0.87124 (+/-0.008458)
+      3 ( ) accept suboptimal roc_auc=0.86909 (+/-0.008582)
 
 ---
 
     Code
       set.seed(1)
       f_wflow_1 <- wflow %>% tune_sim_anneal(rs, iter = 3)
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.87657
-      1 ( ) accept suboptimal  roc_auc=0.87345	(+/-0.008739)
-      2 ( ) accept suboptimal  roc_auc=0.87124	(+/-0.008458)
-      3 ( ) accept suboptimal  roc_auc=0.86909	(+/-0.008582)
+      1 ( ) accept suboptimal roc_auc=0.87345 (+/-0.008739)
+      2 ( ) accept suboptimal roc_auc=0.87124 (+/-0.008458)
+      3 ( ) accept suboptimal roc_auc=0.86909 (+/-0.008582)
 

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -9,7 +9,7 @@
       >  Generating a set of 1 initial parameter results
       v Initialization complete
       
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.82520
     Message <simpleMessage>
@@ -17,67 +17,79 @@
       v Fold1, Repeat1: preprocessor 1/1
       i Fold1, Repeat1: preprocessor 1/1, model 1/1
       v Fold1, Repeat1: preprocessor 1/1, model 1/1
+      i Fold1, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat1: preprocessor 1/1
       v Fold2, Repeat1: preprocessor 1/1
       i Fold2, Repeat1: preprocessor 1/1, model 1/1
       v Fold2, Repeat1: preprocessor 1/1, model 1/1
+      i Fold2, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat1: preprocessor 1/1
       v Fold3, Repeat1: preprocessor 1/1
       i Fold3, Repeat1: preprocessor 1/1, model 1/1
       v Fold3, Repeat1: preprocessor 1/1, model 1/1
+      i Fold3, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold1, Repeat2: preprocessor 1/1
       v Fold1, Repeat2: preprocessor 1/1
       i Fold1, Repeat2: preprocessor 1/1, model 1/1
       v Fold1, Repeat2: preprocessor 1/1, model 1/1
+      i Fold1, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat2: preprocessor 1/1
       v Fold2, Repeat2: preprocessor 1/1
       i Fold2, Repeat2: preprocessor 1/1, model 1/1
       v Fold2, Repeat2: preprocessor 1/1, model 1/1
+      i Fold2, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat2: preprocessor 1/1
       v Fold3, Repeat2: preprocessor 1/1
       i Fold3, Repeat2: preprocessor 1/1, model 1/1
       v Fold3, Repeat2: preprocessor 1/1, model 1/1
+      i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
-    Message <rlang_message>
-      1 ( ) accept suboptimal  roc_auc=0.75661	(+/-0.006729)
+    Message <cliMessage>
+      1 ( ) accept suboptimal roc_auc=0.75661 (+/-0.006729)
     Message <simpleMessage>
       i Fold1, Repeat1: preprocessor 1/1
       v Fold1, Repeat1: preprocessor 1/1
       i Fold1, Repeat1: preprocessor 1/1, model 1/1
       v Fold1, Repeat1: preprocessor 1/1, model 1/1
+      i Fold1, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat1: preprocessor 1/1
       v Fold2, Repeat1: preprocessor 1/1
       i Fold2, Repeat1: preprocessor 1/1, model 1/1
       v Fold2, Repeat1: preprocessor 1/1, model 1/1
+      i Fold2, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat1: preprocessor 1/1
       v Fold3, Repeat1: preprocessor 1/1
       i Fold3, Repeat1: preprocessor 1/1, model 1/1
       v Fold3, Repeat1: preprocessor 1/1, model 1/1
+      i Fold3, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold1, Repeat2: preprocessor 1/1
       v Fold1, Repeat2: preprocessor 1/1
       i Fold1, Repeat2: preprocessor 1/1, model 1/1
       v Fold1, Repeat2: preprocessor 1/1, model 1/1
+      i Fold1, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat2: preprocessor 1/1
       v Fold2, Repeat2: preprocessor 1/1
       i Fold2, Repeat2: preprocessor 1/1, model 1/1
       v Fold2, Repeat2: preprocessor 1/1, model 1/1
+      i Fold2, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat2: preprocessor 1/1
       v Fold3, Repeat2: preprocessor 1/1
       i Fold3, Repeat2: preprocessor 1/1, model 1/1
       v Fold3, Repeat2: preprocessor 1/1, model 1/1
+      i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
-    Message <rlang_message>
-      2 + better suboptimal  roc_auc=0.79946	(+/-0.008393)
+    Message <cliMessage>
+      2 + better suboptimal roc_auc=0.79946 (+/-0.008393)
 
 # variable interface
 
@@ -90,7 +102,7 @@
       >  Generating a set of 1 initial parameter results
       v Initialization complete
       
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.82520
     Message <simpleMessage>
@@ -98,67 +110,79 @@
       v Fold1, Repeat1: preprocessor 1/1
       i Fold1, Repeat1: preprocessor 1/1, model 1/1
       v Fold1, Repeat1: preprocessor 1/1, model 1/1
+      i Fold1, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat1: preprocessor 1/1
       v Fold2, Repeat1: preprocessor 1/1
       i Fold2, Repeat1: preprocessor 1/1, model 1/1
       v Fold2, Repeat1: preprocessor 1/1, model 1/1
+      i Fold2, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat1: preprocessor 1/1
       v Fold3, Repeat1: preprocessor 1/1
       i Fold3, Repeat1: preprocessor 1/1, model 1/1
       v Fold3, Repeat1: preprocessor 1/1, model 1/1
+      i Fold3, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold1, Repeat2: preprocessor 1/1
       v Fold1, Repeat2: preprocessor 1/1
       i Fold1, Repeat2: preprocessor 1/1, model 1/1
       v Fold1, Repeat2: preprocessor 1/1, model 1/1
+      i Fold1, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat2: preprocessor 1/1
       v Fold2, Repeat2: preprocessor 1/1
       i Fold2, Repeat2: preprocessor 1/1, model 1/1
       v Fold2, Repeat2: preprocessor 1/1, model 1/1
+      i Fold2, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat2: preprocessor 1/1
       v Fold3, Repeat2: preprocessor 1/1
       i Fold3, Repeat2: preprocessor 1/1, model 1/1
       v Fold3, Repeat2: preprocessor 1/1, model 1/1
+      i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
-    Message <rlang_message>
-      1 ( ) accept suboptimal  roc_auc=0.75661	(+/-0.006729)
+    Message <cliMessage>
+      1 ( ) accept suboptimal roc_auc=0.75661 (+/-0.006729)
     Message <simpleMessage>
       i Fold1, Repeat1: preprocessor 1/1
       v Fold1, Repeat1: preprocessor 1/1
       i Fold1, Repeat1: preprocessor 1/1, model 1/1
       v Fold1, Repeat1: preprocessor 1/1, model 1/1
+      i Fold1, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat1: preprocessor 1/1
       v Fold2, Repeat1: preprocessor 1/1
       i Fold2, Repeat1: preprocessor 1/1, model 1/1
       v Fold2, Repeat1: preprocessor 1/1, model 1/1
+      i Fold2, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat1: preprocessor 1/1
       v Fold3, Repeat1: preprocessor 1/1
       i Fold3, Repeat1: preprocessor 1/1, model 1/1
       v Fold3, Repeat1: preprocessor 1/1, model 1/1
+      i Fold3, Repeat1: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat1: preprocessor 1/1, model 1/1 (predictions)
       i Fold1, Repeat2: preprocessor 1/1
       v Fold1, Repeat2: preprocessor 1/1
       i Fold1, Repeat2: preprocessor 1/1, model 1/1
       v Fold1, Repeat2: preprocessor 1/1, model 1/1
+      i Fold1, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold1, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold2, Repeat2: preprocessor 1/1
       v Fold2, Repeat2: preprocessor 1/1
       i Fold2, Repeat2: preprocessor 1/1, model 1/1
       v Fold2, Repeat2: preprocessor 1/1, model 1/1
+      i Fold2, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold2, Repeat2: preprocessor 1/1, model 1/1 (predictions)
       i Fold3, Repeat2: preprocessor 1/1
       v Fold3, Repeat2: preprocessor 1/1
       i Fold3, Repeat2: preprocessor 1/1, model 1/1
       v Fold3, Repeat2: preprocessor 1/1, model 1/1
+      i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
-    Message <rlang_message>
-      2 + better suboptimal  roc_auc=0.79946	(+/-0.008393)
+    Message <cliMessage>
+      2 + better suboptimal roc_auc=0.79946 (+/-0.008393)
 
 ---
 
@@ -168,10 +192,11 @@
         control = control_sim_anneal(verbose = FALSE))
     Message <rlang_message>
       There were 2 previous iterations
+    Message <cliMessage>
       Optimizing roc_auc
-      2 v initial            roc_auc=0.8252	(+/-0.005662)
-      3 <3 new best           roc_auc=0.82851	(+/-0.004901)
-      4 <3 new best           roc_auc=0.83405	(+/-0.004564)
+      2 v initial roc_auc=0.8252 (+/-0.005662)
+      3 <3 new best roc_auc=0.82851 (+/-0.004901)
+      4 <3 new best roc_auc=0.83405 (+/-0.004564)
 
 ---
 
@@ -179,28 +204,28 @@
       set.seed(1)
       new_new_res <- var_wflow %>% tune_sim_anneal(cell_folds, iter = 2, initial = grid_res,
         control = control_sim_anneal(verbose = FALSE))
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.83924
-      1 ( ) accept suboptimal  roc_auc=0.83776	(+/-0.007509)
-      2 <3 new best           roc_auc=0.84	(+/-0.00542)
+      1 ( ) accept suboptimal roc_auc=0.83776 (+/-0.007509)
+      2 <3 new best roc_auc=0.84 (+/-0.00542)
 
 # unfinalized parameters
 
     Code
       set.seed(40)
       rf_res_finetune <- wf_rf %>% tune_sim_anneal(resamples = bt, initial = rf_res)
-    Message <rlang_message>
+    Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.86248
-       1 ( ) accept suboptimal  roc_auc=0.86132	(+/-0.007045)
-       2 ( ) accept suboptimal  roc_auc=0.85987	(+/-0.007598)
-       3 + better suboptimal  roc_auc=0.86155	(+/-0.007228)
-       4 + better suboptimal  roc_auc=0.86193	(+/-0.007212)
-       5 ( ) accept suboptimal  roc_auc=0.86108	(+/-0.00727)
-       6 ( ) accept suboptimal  roc_auc=0.85992	(+/-0.007641)
-       7 + better suboptimal  roc_auc=0.86045	(+/-0.007405)
-       8 x restart from best  roc_auc=0.85863	(+/-0.007596)
-       9 ( ) accept suboptimal  roc_auc=0.8623	(+/-0.007265)
-      10 <3 new best           roc_auc=0.86273	(+/-0.007569)
+      1 ( ) accept suboptimal roc_auc=0.86132 (+/-0.007045)
+      2 ( ) accept suboptimal roc_auc=0.85987 (+/-0.007598)
+      3 + better suboptimal roc_auc=0.86155 (+/-0.007228)
+      4 + better suboptimal roc_auc=0.86193 (+/-0.007212)
+      5 ( ) accept suboptimal roc_auc=0.86108 (+/-0.00727)
+      6 ( ) accept suboptimal roc_auc=0.85992 (+/-0.007641)
+      7 + better suboptimal roc_auc=0.86045 (+/-0.007405)
+      8 x restart from best roc_auc=0.85863 (+/-0.007596)
+      9 ( ) accept suboptimal roc_auc=0.8623 (+/-0.007265)
+      10 <3 new best roc_auc=0.86273 (+/-0.007569)
 

--- a/tests/testthat/_snaps/win-loss-overall.md
+++ b/tests/testthat/_snaps/win-loss-overall.md
@@ -7,6 +7,7 @@
     Message <rlang_message>
       i Racing will maximize the roc_auc metric.
       i Resamples are analyzed in a random order.
+    Message <cliMessage>
       i Fold3, Repeat1: 0 eliminated; 5 candidates remain.
       i Fold2, Repeat2: 0 eliminated; 5 candidates remain.
       i Fold3, Repeat2: 0 eliminated; 5 candidates remain.


### PR DESCRIPTION
Integrates with https://github.com/tidymodels/tune/pull/593 to enable interactive tuning issue logging.

This PR also transitions a few `rlang::inform()` calls to `cli::cli_bullets()`, the latter of which is aware of the progress bar.