### PR TITLE
stash last result for `Last.tune.results`

### DIFF
--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -295,6 +295,8 @@ tune_race_anova_workflow <-
       }
     }
 
+    .stash_last_result(res)
+
     res
   }
 

--- a/R/tune_race_win_loss.R
+++ b/R/tune_race_win_loss.R
@@ -301,5 +301,6 @@ tune_race_win_loss_workflow <-
       }
     }
 
+    .stash_last_result(res)
     res
   }

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -353,6 +353,7 @@ tune_sim_anneal_workflow <-
         unsummarized, param_info,
         metrics, y_names, rset_info, object
       )
+      .stash_last_result(out)
       return(out)
     })
 
@@ -498,6 +499,9 @@ tune_sim_anneal_workflow <-
         dplyr::arrange(.iter, .config)
       save(result_history, file = file.path(tempdir(), "sa_history.RData"))
     }
+
+    .stash_last_result(unsummarized)
+
     # Note; this line is probably not executed due to on.exit():
     unsummarized
   }

--- a/tests/testthat/test-anova-overall.R
+++ b/tests/testthat/test-anova-overall.R
@@ -11,6 +11,7 @@ test_that("formula interface", {
   })
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) < nrow(grid_mod) * 2)
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------
@@ -27,6 +28,7 @@ test_that("recipe interface", {
   })
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) < nrow(grid_mod) * 2)
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------
@@ -43,6 +45,7 @@ test_that("variable interface", {
   })
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res))  < nrow(grid_mod) * 2)
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -10,6 +10,7 @@ test_that("formula interface", {
   })
   expect_equal(class(res), c("iteration_results", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 6)
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------
@@ -30,6 +31,7 @@ test_that("recipe interface", {
 
   expect_equal(class(res), c("iteration_results", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 6)
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------
@@ -46,6 +48,7 @@ test_that("variable interface", {
   })
   expect_equal(class(res), c("iteration_results", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 6)
+  expect_equal(res, .Last.tune.result)
 
   # Check to see if iterations are picked up when an iterative object is used
   # as the initial object
@@ -61,6 +64,7 @@ test_that("variable interface", {
   expect_true(nrow(collect_metrics(new_res)) == 10)
   expect_true(max(new_res$.iter) == 4)
   expect_true(sum(grepl("^initial", collect_metrics(new_res)$.config)) == 6)
+  expect_equal(new_res, .Last.tune.result)
 
   # but not for non-iterative objects
   set.seed(1)
@@ -78,6 +82,7 @@ test_that("variable interface", {
   expect_true(nrow(collect_metrics(new_new_res)) == 8)
   expect_true(max(new_new_res$.iter) == 2)
   expect_true(sum(grepl("^initial", collect_metrics(new_new_res)$.config)) == 4)
+  expect_equal(new_new_res, .Last.tune.result)
 })
 
 

--- a/tests/testthat/test-win-loss-overall.R
+++ b/tests/testthat/test-win-loss-overall.R
@@ -13,6 +13,7 @@ test_that("formula interface", {
 
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 10) # this run has no elmimination
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------
@@ -29,6 +30,7 @@ test_that("recipe interface", {
   })
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) < 10)
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------
@@ -45,6 +47,7 @@ test_that("variable interface", {
   })
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 10) # no elimination
+  expect_equal(res, .Last.tune.result)
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #61.

This PR ensures that `.Last.tune.result` gives correct output for `tune_race_anova()`, `tune_race_win_loss()`, and `tune_sim_anneal()` when those functions complete or where we can hook in to existing exit handlers. This PR does not introduce additional exit handlers.

Before this PR:

``` r
library(tidymodels)
library(finetune)

spec <- linear_reg(engine = "glmnet", penalty = tune(), mixture = tune())
form <- log(Sale_Price) ~ .
res <- bootstraps(ames, 5)
  
# race anova -----------------
tune_race_anova(spec, form, res)
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1067]> Bootstrap2      1 <tibble [20 × 6]> <tibble [0 × 3]>
#> 2 <split [2930/1059]> Bootstrap4      2 <tibble [20 × 6]> <tibble [0 × 3]>
#> 3 <split [2930/1081]> Bootstrap5      3 <tibble [20 × 6]> <tibble [0 × 3]>
#> 4 <split [2930/1041]> Bootstrap1      5 <tibble [2 × 6]>  <tibble [0 × 3]>
#> 5 <split [2930/1062]> Bootstrap3      4 <tibble [2 × 6]>  <tibble [0 × 3]>

.Last.tune.result
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 2 × 5
#>   splits              id         .order .metrics         .notes          
#>   <list>              <chr>       <int> <list>           <list>          
#> 1 <split [2930/1041]> Bootstrap1      5 <tibble [2 × 6]> <tibble [0 × 3]>
#> 2 <split [2930/1062]> Bootstrap3      4 <tibble [2 × 6]> <tibble [0 × 3]>

# race w/l -------------------
tune_race_win_loss(spec, form, res)
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1041]> Bootstrap1      2 <tibble [20 × 6]> <tibble [0 × 3]>
#> 2 <split [2930/1059]> Bootstrap4      1 <tibble [20 × 6]> <tibble [0 × 3]>
#> 3 <split [2930/1081]> Bootstrap5      3 <tibble [20 × 6]> <tibble [0 × 3]>
#> 4 <split [2930/1062]> Bootstrap3      4 <tibble [20 × 6]> <tibble [0 × 3]>
#> 5 <split [2930/1067]> Bootstrap2      5 <tibble [20 × 6]> <tibble [0 × 3]>

.Last.tune.result
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 1 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1067]> Bootstrap2      5 <tibble [20 × 6]> <tibble [0 × 3]>

# simulated annealing --------
tune_sim_anneal(spec, form, res)
#> Optimizing rmse
#> Initial best: 0.16589
#> 1 ◯ accept suboptimal rmse=0.17012 (+/-0.005112)
#> 2 ◯ accept suboptimal rmse=0.17035 (+/-0.0052)
#> 3 + better suboptimal rmse=0.17027 (+/-0.005165)
#> 4 ◯ accept suboptimal rmse=0.17031 (+/-0.005187)
#> 5 ◯ accept suboptimal rmse=0.17043 (+/-0.005232)
#> 6 + better suboptimal rmse=0.17038 (+/-0.005213)
#> 7 ◯ accept suboptimal rmse=0.17062 (+/-0.005284)
#> 8 ✖ restart from best rmse=0.1708 (+/-0.005306)
#> 9 ◯ accept suboptimal rmse=0.17003 (+/-0.005042)
#> 10 + better suboptimal rmse=0.16984 (+/-0.004921)
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 55 × 5
#>    splits              id         .metrics         .notes           .iter
#>    <list>              <chr>      <list>           <list>           <int>
#>  1 <split [2930/1041]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  2 <split [2930/1067]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  3 <split [2930/1062]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  4 <split [2930/1059]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  5 <split [2930/1081]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  6 <split [2930/1041]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  7 <split [2930/1067]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  8 <split [2930/1062]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  9 <split [2930/1059]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>     1
#> 10 <split [2930/1081]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>     1
#> # … with 45 more rows

.Last.tune.result
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 4
#>   splits              id         .metrics         .notes          
#>   <list>              <chr>      <list>           <list>          
#> 1 <split [2930/1041]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>
#> 2 <split [2930/1067]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>
#> 3 <split [2930/1062]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>
#> 4 <split [2930/1059]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>
#> 5 <split [2930/1081]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>
```

Now:

``` r
library(tidymodels)
library(finetune)

spec <- linear_reg(engine = "glmnet", penalty = tune(), mixture = tune())
form <- log(Sale_Price) ~ .
res <- bootstraps(ames, 5)
  
# race anova -----------------
tune_race_anova(spec, form, res)
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1076]> Bootstrap1      2 <tibble [20 × 6]> <tibble [0 × 3]>
#> 2 <split [2930/1110]> Bootstrap3      1 <tibble [20 × 6]> <tibble [0 × 3]>
#> 3 <split [2930/1084]> Bootstrap5      3 <tibble [20 × 6]> <tibble [0 × 3]>
#> 4 <split [2930/1084]> Bootstrap4      4 <tibble [8 × 6]>  <tibble [0 × 3]>
#> 5 <split [2930/1080]> Bootstrap2      5 <tibble [4 × 6]>  <tibble [0 × 3]>

.Last.tune.result
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1076]> Bootstrap1      2 <tibble [20 × 6]> <tibble [0 × 3]>
#> 2 <split [2930/1110]> Bootstrap3      1 <tibble [20 × 6]> <tibble [0 × 3]>
#> 3 <split [2930/1084]> Bootstrap5      3 <tibble [20 × 6]> <tibble [0 × 3]>
#> 4 <split [2930/1084]> Bootstrap4      4 <tibble [8 × 6]>  <tibble [0 × 3]>
#> 5 <split [2930/1080]> Bootstrap2      5 <tibble [4 × 6]>  <tibble [0 × 3]>

# race w/l -------------------
tune_race_win_loss(spec, form, res)
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1080]> Bootstrap2      2 <tibble [20 × 6]> <tibble [1 × 3]>
#> 2 <split [2930/1110]> Bootstrap3      3 <tibble [20 × 6]> <tibble [1 × 3]>
#> 3 <split [2930/1084]> Bootstrap4      1 <tibble [20 × 6]> <tibble [1 × 3]>
#> 4 <split [2930/1076]> Bootstrap1      4 <tibble [18 × 6]> <tibble [0 × 3]>
#> 5 <split [2930/1084]> Bootstrap5      5 <tibble [18 × 6]> <tibble [0 × 3]>

.Last.tune.result
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 5 × 5
#>   splits              id         .order .metrics          .notes          
#>   <list>              <chr>       <int> <list>            <list>          
#> 1 <split [2930/1080]> Bootstrap2      2 <tibble [20 × 6]> <tibble [1 × 3]>
#> 2 <split [2930/1110]> Bootstrap3      3 <tibble [20 × 6]> <tibble [1 × 3]>
#> 3 <split [2930/1084]> Bootstrap4      1 <tibble [20 × 6]> <tibble [1 × 3]>
#> 4 <split [2930/1076]> Bootstrap1      4 <tibble [18 × 6]> <tibble [0 × 3]>
#> 5 <split [2930/1084]> Bootstrap5      5 <tibble [18 × 6]> <tibble [0 × 3]>

# simulated annealing --------
tune_sim_anneal(spec, form, res)
#> Optimizing rmse
#> Initial best: 0.17056
#> 1 ◯ accept suboptimal rmse=0.17066 (+/-0.01179)
#> 2 ◯ accept suboptimal rmse=0.17069 (+/-0.01179)
#> 3 + better suboptimal rmse=0.17067 (+/-0.01179)
#> 4 + better suboptimal rmse=0.17057 (+/-0.01179)
#> 5 ◯ accept suboptimal rmse=0.17068 (+/-0.01178)
#> 6 + better suboptimal rmse=0.17059 (+/-0.01179)
#> 7 ♥ new best rmse=0.1705 (+/-0.01177)
#> 8 ◯ accept suboptimal rmse=0.17051 (+/-0.01173)
#> 9 ♥ new best rmse=0.17041 (+/-0.01165)
#> 10 ◯ accept suboptimal rmse=0.17044 (+/-0.01168)
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 55 × 5
#>    splits              id         .metrics         .notes           .iter
#>    <list>              <chr>      <list>           <list>           <int>
#>  1 <split [2930/1076]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  2 <split [2930/1080]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  3 <split [2930/1110]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  4 <split [2930/1084]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  5 <split [2930/1084]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  6 <split [2930/1076]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  7 <split [2930/1080]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  8 <split [2930/1110]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  9 <split [2930/1084]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>     1
#> 10 <split [2930/1084]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>     1
#> # … with 45 more rows

.Last.tune.result
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 55 × 5
#>    splits              id         .metrics         .notes           .iter
#>    <list>              <chr>      <list>           <list>           <int>
#>  1 <split [2930/1076]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  2 <split [2930/1080]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  3 <split [2930/1110]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  4 <split [2930/1084]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  5 <split [2930/1084]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>     0
#>  6 <split [2930/1076]> Bootstrap1 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  7 <split [2930/1080]> Bootstrap2 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  8 <split [2930/1110]> Bootstrap3 <tibble [2 × 6]> <tibble [0 × 3]>     1
#>  9 <split [2930/1084]> Bootstrap4 <tibble [2 × 6]> <tibble [0 × 3]>     1
#> 10 <split [2930/1084]> Bootstrap5 <tibble [2 × 6]> <tibble [0 × 3]>     1
#> # … with 45 more rows
```
