### PR TITLE
fix justification in progress updates

### DIFF
--- a/R/sim_anneal_helpers.R
+++ b/R/sim_anneal_helpers.R
@@ -349,6 +349,7 @@ format_event <- function(x) {
   ) %>%
     dplyr::mutate(
       new = format(orig, justify = "left"),
+      new = gsub(" ", "\u00a0", new, fixed = TRUE),
       result = paste(symb, new)
     )
   color_event(result_key$result[result_key$orig == x])

--- a/tests/testthat/_snaps/sa-misc.md
+++ b/tests/testthat/_snaps/sa-misc.md
@@ -6,9 +6,9 @@
     Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.85161
-      1 ( ) accept suboptimal roc_auc=0.84064 (+/-0.01096)
-      2 ( ) accept suboptimal roc_auc=0.83789 (+/-0.01086)
-      3 ( ) accept suboptimal roc_auc=0.83261 (+/-0.0109)
+      1 ( ) accept suboptimal  roc_auc=0.84064 (+/-0.01096)
+      2 ( ) accept suboptimal  roc_auc=0.83789 (+/-0.01086)
+      3 ( ) accept suboptimal  roc_auc=0.83261 (+/-0.0109)
 
 ---
 
@@ -18,9 +18,9 @@
     Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.85192
-      1 ( ) accept suboptimal roc_auc=0.848 (+/-0.01072)
-      2 ( ) accept suboptimal roc_auc=0.84678 (+/-0.01067)
-      3 ( ) accept suboptimal roc_auc=0.84534 (+/-0.01097)
+      1 ( ) accept suboptimal  roc_auc=0.848 (+/-0.01072)
+      2 ( ) accept suboptimal  roc_auc=0.84678 (+/-0.01067)
+      3 ( ) accept suboptimal  roc_auc=0.84534 (+/-0.01097)
 
 ---
 
@@ -30,9 +30,9 @@
     Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.87657
-      1 ( ) accept suboptimal roc_auc=0.87345 (+/-0.008739)
-      2 ( ) accept suboptimal roc_auc=0.87124 (+/-0.008458)
-      3 ( ) accept suboptimal roc_auc=0.86909 (+/-0.008582)
+      1 ( ) accept suboptimal  roc_auc=0.87345 (+/-0.008739)
+      2 ( ) accept suboptimal  roc_auc=0.87124 (+/-0.008458)
+      3 ( ) accept suboptimal  roc_auc=0.86909 (+/-0.008582)
 
 ---
 
@@ -42,7 +42,7 @@
     Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.87657
-      1 ( ) accept suboptimal roc_auc=0.87345 (+/-0.008739)
-      2 ( ) accept suboptimal roc_auc=0.87124 (+/-0.008458)
-      3 ( ) accept suboptimal roc_auc=0.86909 (+/-0.008582)
+      1 ( ) accept suboptimal  roc_auc=0.87345 (+/-0.008739)
+      2 ( ) accept suboptimal  roc_auc=0.87124 (+/-0.008458)
+      3 ( ) accept suboptimal  roc_auc=0.86909 (+/-0.008582)
 

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -50,7 +50,7 @@
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
     Message <cliMessage>
-      1 ( ) accept suboptimal roc_auc=0.75661 (+/-0.006729)
+      1 ( ) accept suboptimal  roc_auc=0.75661 (+/-0.006729)
     Message <simpleMessage>
       i Fold1, Repeat1: preprocessor 1/1
       v Fold1, Repeat1: preprocessor 1/1
@@ -89,7 +89,7 @@
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
     Message <cliMessage>
-      2 + better suboptimal roc_auc=0.79946 (+/-0.008393)
+      2 + better suboptimal  roc_auc=0.79946 (+/-0.008393)
 
 # variable interface
 
@@ -143,7 +143,7 @@
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
     Message <cliMessage>
-      1 ( ) accept suboptimal roc_auc=0.75661 (+/-0.006729)
+      1 ( ) accept suboptimal  roc_auc=0.75661 (+/-0.006729)
     Message <simpleMessage>
       i Fold1, Repeat1: preprocessor 1/1
       v Fold1, Repeat1: preprocessor 1/1
@@ -182,7 +182,7 @@
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (extracts)
       i Fold3, Repeat2: preprocessor 1/1, model 1/1 (predictions)
     Message <cliMessage>
-      2 + better suboptimal roc_auc=0.79946 (+/-0.008393)
+      2 + better suboptimal  roc_auc=0.79946 (+/-0.008393)
 
 ---
 
@@ -194,9 +194,9 @@
       There were 2 previous iterations
     Message <cliMessage>
       Optimizing roc_auc
-      2 v initial roc_auc=0.8252 (+/-0.005662)
-      3 <3 new best roc_auc=0.82851 (+/-0.004901)
-      4 <3 new best roc_auc=0.83405 (+/-0.004564)
+      2 v initial            roc_auc=0.8252 (+/-0.005662)
+      3 <3 new best           roc_auc=0.82851 (+/-0.004901)
+      4 <3 new best           roc_auc=0.83405 (+/-0.004564)
 
 ---
 
@@ -207,8 +207,8 @@
     Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.83924
-      1 ( ) accept suboptimal roc_auc=0.83776 (+/-0.007509)
-      2 <3 new best roc_auc=0.84 (+/-0.00542)
+      1 ( ) accept suboptimal  roc_auc=0.83776 (+/-0.007509)
+      2 <3 new best           roc_auc=0.84 (+/-0.00542)
 
 # unfinalized parameters
 
@@ -218,14 +218,14 @@
     Message <cliMessage>
       Optimizing roc_auc
       Initial best: 0.86248
-      1 ( ) accept suboptimal roc_auc=0.86132 (+/-0.007045)
-      2 ( ) accept suboptimal roc_auc=0.85987 (+/-0.007598)
-      3 + better suboptimal roc_auc=0.86155 (+/-0.007228)
-      4 + better suboptimal roc_auc=0.86193 (+/-0.007212)
-      5 ( ) accept suboptimal roc_auc=0.86108 (+/-0.00727)
-      6 ( ) accept suboptimal roc_auc=0.85992 (+/-0.007641)
-      7 + better suboptimal roc_auc=0.86045 (+/-0.007405)
-      8 x restart from best roc_auc=0.85863 (+/-0.007596)
-      9 ( ) accept suboptimal roc_auc=0.8623 (+/-0.007265)
-      10 <3 new best roc_auc=0.86273 (+/-0.007569)
+      1 ( ) accept suboptimal  roc_auc=0.86132 (+/-0.007045)
+      2 ( ) accept suboptimal  roc_auc=0.85987 (+/-0.007598)
+      3 + better suboptimal  roc_auc=0.86155 (+/-0.007228)
+      4 + better suboptimal  roc_auc=0.86193 (+/-0.007212)
+      5 ( ) accept suboptimal  roc_auc=0.86108 (+/-0.00727)
+      6 ( ) accept suboptimal  roc_auc=0.85992 (+/-0.007641)
+      7 + better suboptimal  roc_auc=0.86045 (+/-0.007405)
+      8 x restart from best  roc_auc=0.85863 (+/-0.007596)
+      9 ( ) accept suboptimal  roc_auc=0.8623 (+/-0.007265)
+      10 <3 new best           roc_auc=0.86273 (+/-0.007569)
 


### PR DESCRIPTION
I broke the code for justification of "columns" in progress updates in #60. This PR substitutes whitespace with an escaped whitespace character--see `rlib/cli#509`.

The diffs make the columns appear not justified, but they look correct interactively.