### PR TITLE
rebuild readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,36 +63,36 @@ sa_res <-
 #> ! The `default` argument of `new_quant_param()` is deprecated as of dials
 #>   1.0.1.
 #> ℹ The deprecated feature was likely used in the discrim package.
-#>   Please report the issue at <]8;;https://github.com/tidymodels/discrim/issueshttps://github.com/tidymodels/discrim/issues]8;;>.
+#>   Please report the issue at <https://github.com/tidymodels/discrim/issues>.
 #> Optimizing roc_auc
 #> Initial best: 0.86480
-#> 1 ♥ new best roc_auc=0.87327 (+/-0.004592)
-#> 2 ♥ new best roc_auc=0.87915 (+/-0.003864)
-#> 3 ◯ accept suboptimal roc_auc=0.87029 (+/-0.004994)
-#> 4 + better suboptimal roc_auc=0.87171 (+/-0.004717)
-#> 5 ◯ accept suboptimal roc_auc=0.86944 (+/-0.005081)
-#> 6 ◯ accept suboptimal roc_auc=0.86812 (+/-0.0052)
-#> 7 ♥ new best roc_auc=0.88172 (+/-0.003647)
-#> 8 ◯ accept suboptimal roc_auc=0.87678 (+/-0.004276)
-#> 9 ◯ accept suboptimal roc_auc=0.8627 (+/-0.005784)
-#> 10 + better suboptimal roc_auc=0.87003 (+/-0.005106)
-#> 11 + better suboptimal roc_auc=0.87088 (+/-0.004962)
-#> 12 ◯ accept suboptimal roc_auc=0.86803 (+/-0.005195)
-#> 13 ◯ accept suboptimal roc_auc=0.85294 (+/-0.006498)
+#> 1 ♥ new best           roc_auc=0.87327 (+/-0.004592)
+#> 2 ♥ new best           roc_auc=0.87915 (+/-0.003864)
+#> 3 ◯ accept suboptimal  roc_auc=0.87029 (+/-0.004994)
+#> 4 + better suboptimal  roc_auc=0.87171 (+/-0.004717)
+#> 5 ◯ accept suboptimal  roc_auc=0.86944 (+/-0.005081)
+#> 6 ◯ accept suboptimal  roc_auc=0.86812 (+/-0.0052)
+#> 7 ♥ new best           roc_auc=0.88172 (+/-0.003647)
+#> 8 ◯ accept suboptimal  roc_auc=0.87678 (+/-0.004276)
+#> 9 ◯ accept suboptimal  roc_auc=0.8627 (+/-0.005784)
+#> 10 + better suboptimal  roc_auc=0.87003 (+/-0.005106)
+#> 11 + better suboptimal  roc_auc=0.87088 (+/-0.004962)
+#> 12 ◯ accept suboptimal  roc_auc=0.86803 (+/-0.005195)
+#> 13 ◯ accept suboptimal  roc_auc=0.85294 (+/-0.006498)
 #> 14 ─ discard suboptimal roc_auc=0.84689 (+/-0.006867)
-#> 15 ✖ restart from best roc_auc=0.85021 (+/-0.006623)
-#> 16 ◯ accept suboptimal roc_auc=0.87607 (+/-0.004318)
-#> 17 ◯ accept suboptimal roc_auc=0.87245 (+/-0.004799)
-#> 18 + better suboptimal roc_auc=0.87706 (+/-0.004131)
-#> 19 ◯ accept suboptimal roc_auc=0.87213 (+/-0.004791)
-#> 20 ◯ accept suboptimal roc_auc=0.86218 (+/-0.005773)
+#> 15 ✖ restart from best  roc_auc=0.85021 (+/-0.006623)
+#> 16 ◯ accept suboptimal  roc_auc=0.87607 (+/-0.004318)
+#> 17 ◯ accept suboptimal  roc_auc=0.87245 (+/-0.004799)
+#> 18 + better suboptimal  roc_auc=0.87706 (+/-0.004131)
+#> 19 ◯ accept suboptimal  roc_auc=0.87213 (+/-0.004791)
+#> 20 ◯ accept suboptimal  roc_auc=0.86218 (+/-0.005773)
 show_best(sa_res, metric = "roc_auc", n = 2)
 #> # A tibble: 2 × 9
-#>   frac_common_cov frac_ident…¹ .metric .esti…²  mean     n std_err .config .iter
-#>             <dbl>        <dbl> <chr>   <chr>   <dbl> <int>   <dbl> <chr>   <int>
-#> 1           0.308       0.0166 roc_auc binary  0.882    10 0.00365 Iter7       7
-#> 2           0.121       0.0474 roc_auc binary  0.879    10 0.00386 Iter2       2
-#> # … with abbreviated variable names ¹​frac_identity, ²​.estimator
+#>   frac_common_cov frac_identity .metric .estimator  mean     n std_err .config
+#>             <dbl>         <dbl> <chr>   <chr>      <dbl> <int>   <dbl> <chr>  
+#> 1           0.308        0.0166 roc_auc binary     0.882    10 0.00365 Iter7  
+#> 2           0.121        0.0474 roc_auc binary     0.879    10 0.00386 Iter2  
+#> # ℹ 1 more variable: .iter <int>
 ```
 
 The second set of methods are for *racing*. We start off by doing a


### PR DESCRIPTION
Removes the invalid XML character in `<�]8;;`.

Should address the [Actions failures](https://github.com/tidymodels/finetune/actions/runs/4545481816/jobs/8012870917#step:6:129):

```
> if (requireNamespace("spelling", quietly = TRUE)) {
+   spelling::spell_check_test(
+     vignettes = TRUE, error = FALSE,
+     skip_on_cran = TRUE
+   )
+ }
Error in read_xml.raw(charToRaw(enc2utf8(x)), "UTF-8", ..., as_html = as_html,  : 
Error: Error: R CMD check found ERRORs
  PCDATA invalid Char value 27 [9]
Calls: <Anonymous> ... xml_find_all -> <Anonymous> -> read_xml.character -> read_xml.raw
Execution halted
```