### PR TITLE
fix printing for evaluation time for survival models

### DIFF
--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -248,7 +248,7 @@ tune_race_anova_workflow <-
     metric_info <- tibble::as_tibble(metrics)
     analysis_metric <-metric_info$metric[1]
     analysis_max <- metric_info$direction[1] == "maximize"
-    is_dyn <- metric_info$direction[1] == "dynamic_survival_metric"
+    is_dyn <- metric_info$class[1] == "dynamic_survival_metric"
     if (is_dyn) {
       metrics_time <- eval_time[1]
     } else {

--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -265,9 +265,8 @@ tune_race_anova_workflow <-
 
       if (!is.null(metrics_time)) {
         msg <- paste(msg, "at time", format(metrics_time, digits = 3))
-      } else {
-        msg <- paste0(msg, ".")
       }
+      msg <- paste0(msg, ".")
 
       rlang::inform(cols$message$info(paste0(cli::symbol$info, " ", msg)))
       if (control$randomize) {


### PR DESCRIPTION
to close https://github.com/tidymodels/finetune/issues/81

bug turned out to be a simple typo


``` r
library(tidymodels)
library(finetune)
library(censored)
#> Loading required package: survival

set.seed(1)
sim_dat <- prodlim::SimSurv(500) %>%
  mutate(event_time = Surv(time, event)) %>%
  select(event_time, X1, X2)

set.seed(2)
split <- initial_split(sim_dat)
sim_tr <- training(split)
sim_te <- testing(split)
sim_rs <- bootstraps(sim_tr, times = 4)

time_points <- c(10, 1, 5, 15)

mod_spec <-
  decision_tree(cost_complexity = tune()) %>%
  set_mode("censored regression")

grid <- tibble(cost_complexity = 10^c(-10, -2, -1))

gctrl <- control_grid(save_pred = TRUE)
rctrl <- control_race(save_pred = TRUE, verbose_elim = TRUE, verbose = FALSE)

dyn_mtrc  <- metric_set(brier_survival)

set.seed(2193)
aov_dyn_res <-
  mod_spec %>%
  tune_race_anova(
    event_time ~ X1 + X2,
    resamples = sim_rs,
    grid = grid,
    metrics = dyn_mtrc,
    eval_time = time_points,
    control = rctrl
  )
#> ℹ Racing will minimize the brier_survival metric at time 10.
#> ℹ Resamples are analyzed in a random order.
#> ℹ Bootstrap4: 0 eliminated; 3 candidates remain.
```

<sup>Created on 2023-11-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>