### PR TITLE
add eval_time as an attribute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     testthat,
     yardstick
 Remotes:
-    tidymodels/tune
+    tidymodels/tune#767
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finetune
 Title: Additional Functions for Model Tuning
-Version: 1.1.0.9002
+Version: 1.1.0.9003
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),
@@ -19,7 +19,7 @@ URL: https://github.com/tidymodels/finetune,
 BugReports: https://github.com/tidymodels/finetune/issues
 Depends: 
     R (>= 3.5),
-    tune (>= 1.1.2.9000)
+    tune (>= 1.1.2.9001)
 Imports: 
     cli,
     dials (>= 0.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Corrects `.config` output with `save_pred = TRUE` in `tune_sim_anneal()`. The function previously outputted a constant `Model1_Preprocessor1` in the `.predictions` slot, and now provides `.config` values that align with those in `.metrics` (#57).
 
+* An `eval_time` attribute was added to tune objects produced by finetune. 
+
 # finetune 1.0.1
 
 * For racing: 

--- a/R/tune_sim_anneal.R
+++ b/R/tune_sim_anneal.R
@@ -361,6 +361,7 @@ tune_sim_anneal_workflow <-
       tune::new_iteration_results(
         parameters = param_info,
         metrics = metrics,
+        eval_time = eval_time,
         outcomes = y_names,
         rset_info = rset_info,
         workflow = object
@@ -381,10 +382,17 @@ tune_sim_anneal_workflow <-
       if (i < iter) {
         cli::cli_alert_danger("Optimization stopped prematurely; returning current results.")
       }
-      out <- tune::new_iteration_results(
-        unsummarized, param_info,
-        metrics, y_names, rset_info, object
-      )
+      out <-
+        tune::new_iteration_results(
+          unsummarized,
+          parameters = param_info,
+          metrics = metrics,
+          eval_time = eval_time,
+          outcomes = y_names,
+          rset_info = rset_info,
+          workflow = object
+        )
+
       .stash_last_result(out)
       return(out)
     })
@@ -499,6 +507,7 @@ tune_sim_anneal_workflow <-
         tune::new_iteration_results(
           parameters = param_info,
           metrics = metrics,
+          eval_time = eval_time,
           outcomes = y_names,
           rset_info = rset_info,
           workflow = object

--- a/tests/testthat/test-anova-overall.R
+++ b/tests/testthat/test-anova-overall.R
@@ -15,6 +15,7 @@ test_that("formula interface", {
   expect_equal(class(res), c("tune_race", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) < nrow(grid_mod) * 2)
   expect_equal(res, .Last.tune.result)
+  expect_null(.get_tune_eval_times(res))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-sa-decision.R
+++ b/tests/testthat/test-sa-decision.R
@@ -20,6 +20,7 @@ test_that("simulated annealing decisions", {
         parameters = cart_param,
         outcomes = cart_outcomes,
         metrics = cart_metrics,
+        eval_time = NULL,
         rset_info = cart_rset_info
       )
     iter_new_hist <- finetune:::update_history(iter_hist, iter_res, iter_val)

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -11,6 +11,7 @@ test_that("formula interface", {
   expect_equal(class(res), c("iteration_results", "tune_results", "tbl_df", "tbl", "data.frame"))
   expect_true(nrow(collect_metrics(res)) == 6)
   expect_equal(res, .Last.tune.result)
+  expect_null(.get_tune_eval_times(res))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-win-loss-filter.R
+++ b/tests/testthat/test-win-loss-filter.R
@@ -29,6 +29,7 @@ test_that("top-level win/loss filter interfaces", {
   expect_true(inherits(wl_mod, "tune_race"))
   expect_true(inherits(wl_mod, "tune_results"))
   expect_true(tibble::is_tibble((wl_mod)))
+  expect_null(.get_tune_eval_times(wl_mod))
 
   expect_silent({
     set.seed(129)


### PR DESCRIPTION
Updates `tune_sim_anneal()` to save the `eval_time` argument as an attribute due to an API update in tune (tidymodels/tune#767). The racing functions automatically inherit the same from tune, so no changes there. 

Survival-specific tests will be in extratests