### PR TITLE
wrong evaluation time being used to break ties

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finetune
 Title: Additional Functions for Model Tuning
-Version: 1.1.0.9004
+Version: 1.1.0.9005
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -298,7 +298,7 @@ tune_race_anova_workflow <-
       if (nrow(new_grid) > 1) {
         filters_results <- test_parameters_gls(res, control$alpha, opt_metric_time)
         if (sum(filters_results$pass) == 2 & num_ties >= control$num_ties) {
-          filters_results <- tie_breaker(res, control, eval_time = eval_time)
+          filters_results <- tie_breaker(res, control, eval_time = opt_metric_time)
         }
       } else {
         # Depending on the value of control$parallel_over we don't need to do

--- a/R/tune_race_win_loss.R
+++ b/R/tune_race_win_loss.R
@@ -290,7 +290,7 @@ tune_race_win_loss_workflow <-
       if (nrow(new_grid) > 1) {
         filters_results <- test_parameters_bt(res, control$alpha, opt_metric_time)
         if (sum(filters_results$pass) == 2 & num_ties >= control$num_ties) {
-          filters_results <- tie_breaker(res, control)
+          filters_results <- tie_breaker(res, control, eval_time = opt_metric_time)
         }
       } else {
         # Depending on the value of control$parallel_over we don't need to do


### PR DESCRIPTION
For tie breaking during racing, the wrong evaluation times was being used. Tests are going to be in tidymodels/extratests#158