### PR TITLE
address duplicate `eval_time` warnings

### DIFF
--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -229,6 +229,9 @@ tune_race_anova_workflow <-
     check_num_resamples(B, min_rs)
     tmp_resamples <- restore_rset(resamples, 1:min_rs)
 
+    metrics <- tune::check_metrics_arg(metrics, object, call = call)
+    eval_time <- tune::check_eval_time_arg(eval_time, metrics, call = call)
+
     control$pkgs <- c(tune::required_pkgs(object), "workflows", "tidyr", "rlang")
 
     grid_control <- parsnip::condense_control(control, tune::control_grid())
@@ -245,13 +248,10 @@ tune_race_anova_workflow <-
 
     param_names <- tune::.get_tune_parameter_names(res)
 
-    metrics <- tune::.get_tune_metrics(res)
-    metrics <- tune::check_metrics_arg(metrics, object, call = call)
     opt_metric <- tune::first_metric(metrics)
     opt_metric_name <- opt_metric$metric
     maximize <- opt_metric$direction == "maximize"
 
-    eval_time <- tune::check_eval_time_arg(eval_time, metrics, call = call)
     opt_metric_time <- tune::first_eval_time(metrics, opt_metric_name, eval_time)
 
     racing_obj_log(opt_metric_name, opt_metric$direction, control, opt_metric_time)

--- a/R/tune_race_win_loss.R
+++ b/R/tune_race_win_loss.R
@@ -224,6 +224,9 @@ tune_race_win_loss_workflow <-
     check_num_resamples(B, min_rs)
     tmp_resamples <- restore_rset(resamples, 1:min_rs)
 
+    metrics <- tune::check_metrics_arg(metrics, object, call = call)
+    eval_time <- tune::check_eval_time_arg(eval_time, metrics, call = call)
+
     grid_control <- parsnip::condense_control(control, tune::control_grid())
     res <-
       object %>%
@@ -238,13 +241,11 @@ tune_race_win_loss_workflow <-
 
     param_names <- tune::.get_tune_parameter_names(res)
 
-    metrics <- tune::.get_tune_metrics(res)
-    metrics <- tune::check_metrics_arg(metrics, object, call = call)
+
     opt_metric <- tune::first_metric(metrics)
     opt_metric_name <- opt_metric$metric
     maximize <- opt_metric$direction == "maximize"
 
-    eval_time <- tune::check_eval_time_arg(eval_time, metrics, call = call)
     opt_metric_time <- tune::first_eval_time(metrics, opt_metric_name, eval_time)
 
     racing_obj_log(opt_metric_name, opt_metric$direction, control, opt_metric_time)


### PR DESCRIPTION
Closes #91. Closes #92. :)

``` r
library(tidymodels)
library(censored)
#> Loading required package: survival
library(finetune)

lung_surv <- lung %>% 
  dplyr::mutate(surv = Surv(time, status), .keep = "unused")

set.seed(1)
folds <- vfold_cv(mtcars, 5)
lr <- linear_reg(penalty = tune(), engine = "glmnet")
form <- mpg ~ .

# mode is not censored regression 
set.seed(1)
tune_res <- tune_race_anova(lr, form, folds, eval_time = 10)
#> Warning in tune_race_anova(lr, form, folds, eval_time = 10): Evaluation times are only required when the model mode is "censored regression"
#> (and will be ignored).

set.seed(1)
tune_res <- tune_sim_anneal(lr, form, folds, eval_time = 10)
#> Warning in tune_sim_anneal(lr, form, folds, eval_time = 10): Evaluation times are only required when the model mode is "censored regression"
#> (and will be ignored).
#> Optimizing rmse
#> Initial best: 3.25360
#> 1 ♥ new best           rmse=2.7579 (+/-0.247)
#> 2 ─ discard suboptimal rmse=3.9981 (+/-0.4455)
#> 3 ♥ new best           rmse=2.748 (+/-0.4719)
#> 4 ◯ accept suboptimal  rmse=3.0369 (+/-0.1987)
#> 5 ─ discard suboptimal rmse=4.2031 (+/-0.4614)
#> 6 + better suboptimal  rmse=2.9428 (+/-0.1971)
#> 7 ♥ new best           rmse=2.6956 (+/-0.3407)
#> 8 ─ discard suboptimal rmse=3.7762 (+/-0.3859)
#> 9 ─ discard suboptimal rmse=3.0156 (+/-0.1956)
#> 10 ─ discard suboptimal rmse=3.486 (+/-0.2823)

set.seed(1)
tune_res <- tune_race_win_loss(lr, form, folds, eval_time = 10)
#> Warning in tune_race_win_loss(lr, form, folds, eval_time = 10): Evaluation times are only required when the model mode is "censored regression"
#> (and will be ignored).
```

<sup>Created on 2024-01-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>