### PR TITLE
note initial resampling with `verbose_elim` in `tune_race_anova()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # finetune (development version)
 
+* Enabling the `verbose_elim` control option for `tune_race_anova()` will now additionally introduce a message confirming that the function is evaluating against the burn-in resamples.
+
 * Updates based on the new version of tune, primarily for survival analysis models. 
 
 # finetune 1.1.0

--- a/R/tune_race_anova.R
+++ b/R/tune_race_anova.R
@@ -231,6 +231,16 @@ tune_race_anova_workflow <-
 
     control$pkgs <- c(tune::required_pkgs(object), "workflows", "tidyr", "rlang")
 
+    if (control$verbose_elim) {
+      tune_cols <- tune::get_tune_colors()
+      msg <- tune_cols$message$info(
+        paste0(cli::symbol$info,
+               " Evaluating against the initial {min_rs} burn-in resamples.")
+      )
+
+      cli::cli_inform(msg)
+    }
+
     grid_control <- parsnip::condense_control(control, tune::control_grid())
     res <-
       object %>%

--- a/tests/testthat/_snaps/anova-overall.md
+++ b/tests/testthat/_snaps/anova-overall.md
@@ -5,6 +5,7 @@
       res <- f_wflow %>% tune_race_anova(cell_folds, grid = grid_mod, control = control_race(
         verbose_elim = TRUE))
     Message
+      i Evaluating against the initial 3 burn-in resamples.
       i Racing will maximize the roc_auc metric.
       i Resamples are analyzed in a random order.
       i Fold3, Repeat1: 2 eliminated; 2 candidates remain.


### PR DESCRIPTION
Closes #76.