### PR TITLE
check compatibility of `initial` and `param_info`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # finetune (development version)
 
+* Improved error message from `tune_sim_anneal()` when values in the supplied `param_info` do not encompass all values evaluated in the `initial` grid. This most often happens when a user mistakenly supplies different parameter sets to the function that generated the initial results and `tune_sim_anneal()`.
+
 * `autoplot()` methods for racing objects will now use integers in x-axis breaks (#75).
 
 * Enabling the `verbose_elim` control option for `tune_race_anova()` will now additionally introduce a message confirming that the function is evaluating against the burn-in resamples.

--- a/R/sim_anneal_helpers.R
+++ b/R/sim_anneal_helpers.R
@@ -144,20 +144,21 @@ random_real_neighbor <- function(current, hist_values, pset, retain = 1,
 
 encode_set_backwards <- function(x, pset, ...) {
   pset <- pset[pset$id %in% names(x), ]
-  new_vals <- mapply(encode_unit_backwards, pset$object, x,
-                     SIMPLIFY = FALSE, USE.NAMES = FALSE)
+  mapply(check_backwards_encode, pset$object, x, pset$id,
+         SIMPLIFY = FALSE, USE.NAMES = FALSE)
+  new_vals <- purrr::map2(pset$object, x, dials::encode_unit, direction = "backward")
   names(new_vals) <- names(x)
   tibble::as_tibble(new_vals)
 }
 
-encode_unit_backwards <- function(x, value) {
+check_backwards_encode <- function(x, value, id) {
   if (!dials::has_unknowns(x)) {
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
       cli::cli_abort(c(
-        "!" = "The parameter set used when tuning generating the initial \\
-               results isn't compatible with the parameter set supplied \\
-               as {.arg param_info}.",
+        "!" = "The range for parameter {.val {noquote(id)}} used when \\
+               generating initial results isn't compatible with the range \\
+               supplied in {.arg param_info}.",
         "i" = "Possible values of parameters in {.arg param_info} should \\
                encompass all values evaluated in the initial grid."
         ),
@@ -165,8 +166,6 @@ encode_unit_backwards <- function(x, value) {
       )
     }
   }
-
-  dials::encode_unit(x, value, direction = "backward")
 }
 
 sample_by_distance <- function(candidates, existing, retain, pset) {

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -225,7 +225,7 @@
         resamples = car_folds, initial = tune_res_with_bigger_range, iter = 2)
     Message
       Optimizing rmse
-      Initial best: 2284.10000
+      Initial best: 2312.70000
     Condition
       Error in `tune_sim_anneal()`:
       ! The parameter set used when tuning generating the initial results isn't compatible with the parameter set supplied as `param_info`.

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -218,3 +218,18 @@
       9 ( ) accept suboptimal  roc_auc=0.8623 (+/-0.007265)
       10 <3 new best           roc_auc=0.86273 (+/-0.007569)
 
+# incompatible parameter objects
+
+    Code
+      res <- tune_sim_anneal(car_wflow, param_info = parameter_set_with_smaller_range,
+        resamples = car_folds, initial = tune_res_with_bigger_range, iter = 2)
+    Message
+      Optimizing rmse
+      Initial best: 2284.10000
+    Condition
+      Error in `tune_sim_anneal()`:
+      ! The parameter set used when tuning generating the initial results isn't compatible with the parameter set supplied as `param_info`.
+      i Possible values of parameters in `param_info` should encompass all values evaluated in the initial grid.
+    Message
+      x Optimization stopped prematurely; returning current results.
+

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -228,7 +228,7 @@
       
     Condition
       Error in `tune_sim_anneal()`:
-      ! The parameter set used when tuning generating the initial results isn't compatible with the parameter set supplied as `param_info`.
+      ! The range for parameter mtry used when generating initial results isn't compatible with the range supplied in `param_info`.
       i Possible values of parameters in `param_info` should encompass all values evaluated in the initial grid.
     Message
       x Optimization stopped prematurely; returning current results.

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -225,7 +225,7 @@
         resamples = car_folds, initial = tune_res_with_bigger_range, iter = 2)
     Message
       Optimizing rmse
-      Initial best: 2313.60000
+      
     Condition
       Error in `tune_sim_anneal()`:
       ! The parameter set used when tuning generating the initial results isn't compatible with the parameter set supplied as `param_info`.

--- a/tests/testthat/_snaps/sa-overall.md
+++ b/tests/testthat/_snaps/sa-overall.md
@@ -225,7 +225,7 @@
         resamples = car_folds, initial = tune_res_with_bigger_range, iter = 2)
     Message
       Optimizing rmse
-      Initial best: 2312.70000
+      Initial best: 2313.60000
     Condition
       Error in `tune_sim_anneal()`:
       ! The parameter set used when tuning generating the initial results isn't compatible with the parameter set supplied as `param_info`.

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -127,9 +127,9 @@ test_that("incompatible parameter objects", {
   skip_if_not_installed("modeldata")
   skip_if_not_installed("rsample")
 
-
   rf_spec <- parsnip::rand_forest(mode = "regression", mtry = tune::tune())
 
+  set.seed(1)
   grid_with_bigger_range <-
     dials::grid_latin_hypercube(dials::mtry(range = c(1, 16)))
 
@@ -146,9 +146,11 @@ test_that("incompatible parameter objects", {
     grid = grid_with_bigger_range
   )
 
+  set.seed(1)
   parameter_set_with_smaller_range <-
     dials::parameters(dials::mtry(range = c(1, 5)))
 
+  set.seed(1)
   expect_snapshot(error = TRUE, {
     res <-
       tune_sim_anneal(

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -120,6 +120,47 @@ test_that("unfinalized parameters", {
   })
 })
 
+test_that("incompatible parameter objects", {
+  skip_on_cran()
+
+  skip_if_not_installed("ranger")
+  skip_if_not_installed("modeldata")
+  skip_if_not_installed("rsample")
+
+
+  rf_spec <- parsnip::rand_forest(mode = "regression", mtry = tune::tune())
+
+  grid_with_bigger_range <-
+    dials::grid_latin_hypercube(dials::mtry(range = c(1, 16)))
+
+  set.seed(1)
+  car_folds <- rsample::vfold_cv(car_prices, v = 2)
+
+  car_wflow <- workflows::workflow() %>%
+    workflows::add_formula(Price ~ .) %>%
+    workflows::add_model(rf_spec)
+
+  tune_res_with_bigger_range <- tune::tune_grid(
+    car_wflow,
+    resamples = car_folds,
+    grid = grid_with_bigger_range
+  )
+
+  parameter_set_with_smaller_range <-
+    dials::parameters(dials::mtry(range = c(1, 5)))
+
+  expect_snapshot(error = TRUE, {
+    res <-
+      tune_sim_anneal(
+        car_wflow,
+        param_info = parameter_set_with_smaller_range,
+        resamples = car_folds,
+        initial = tune_res_with_bigger_range,
+        iter = 2
+      )
+  })
+})
+
 test_that("set event-level", {
   # See issue 40
   skip_if_not_installed("rpart")

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -151,8 +151,14 @@ test_that("incompatible parameter objects", {
   parameter_set_with_smaller_range <-
     dials::parameters(dials::mtry(range = c(1, 5)))
 
+  scrub_best <- function(lines) {
+    has_best <- grepl("Initial best", lines)
+    lines[has_best] <- ""
+    lines
+  }
+
   set.seed(1)
-  expect_snapshot(error = TRUE, {
+  expect_snapshot(error = TRUE, transform = scrub_best, {
     res <-
       tune_sim_anneal(
         car_wflow,

--- a/tests/testthat/test-sa-overall.R
+++ b/tests/testthat/test-sa-overall.R
@@ -140,6 +140,7 @@ test_that("incompatible parameter objects", {
     workflows::add_formula(Price ~ .) %>%
     workflows::add_model(rf_spec)
 
+  set.seed(1)
   tune_res_with_bigger_range <- tune::tune_grid(
     car_wflow,
     resamples = car_folds,


### PR DESCRIPTION
Closes #59. This code just reproduces the portion of `dials::encode_unit()` methods that picks up on this discrepancy and gives it a more context-specific message.

``` r
library(tidymodels)

set.seed(1)

rf_spec <- rand_forest(mode = "regression", mtry = tune())

grid_with_bigger_range <- grid_latin_hypercube(mtry(range = c(1, 16)))

car_folds <- vfold_cv(car_prices, v = 2)

car_wflow <- workflow() %>% 
  add_formula(Price ~ .) %>% 
  add_model(rf_spec)

tune_res_with_bigger_range <- tune_grid(
  car_wflow, 
  resamples = car_folds,
  grid = grid_with_bigger_range
)
parameter_set_with_smaller_range <- parameters(mtry(range = c(1, 5)))

finetune::tune_sim_anneal(
  car_wflow,
  param_info = parameter_set_with_smaller_range,
  resamples = car_folds,
  initial = tune_res_with_bigger_range,
  iter = 2
)
#> Optimizing rmse
#> Initial best: 2570.90000
#> Error in `tune_sim_anneal()`:
#> ! The parameter set used when tuning generating the initial results
#>   isn't compatible with the parameter set supplied as `param_info`.
#> ℹ Possible values of parameters in `param_info` should encompass all values
#>   evaluated in the initial grid.
#>
#> ✖ Optimization stopped prematurely; returning current results.
#> # Tuning results
#> # 2-fold cross-validation 
#> # A tibble: 2 × 5
#>   splits            id    .metrics         .notes           .iter
#>   <list>            <chr> <list>           <list>           <int>
#> 1 <split [402/402]> Fold1 <tibble [6 × 5]> <tibble [0 × 3]>     0
#> 2 <split [402/402]> Fold2 <tibble [6 × 5]> <tibble [0 × 3]>     0
```

<sup>Created on 2024-01-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

I've situated this solution so that it only applies to `tune_sim_anneal()` as `tune_bayes()` is able to handle that difference just fine.