### PR TITLE
improve metric checking in `show_best.tune_race()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL: https://github.com/tidymodels/finetune,
 BugReports: https://github.com/tidymodels/finetune/issues
 Depends: 
     R (>= 3.5),
-    tune (>= 1.1.2.9004)
+    tune (>= 1.1.2.9011)
 Imports: 
     cli,
     dials (>= 0.1.0),

--- a/R/racing_helpers.R
+++ b/R/racing_helpers.R
@@ -705,10 +705,10 @@ collect_metrics.tune_race <- function(x, summarize = TRUE, all_configs = FALSE, 
 #' different resamples is likely to lead to inappropriate results.
 #' @export
 show_best.tune_race <- function(x, metric = NULL, n = 5, eval_time = NULL, ...) {
-
   if (!is.null(metric)) {
     # What was used to judge the race and how are they being sorted now?
     metrics <- tune::.get_tune_metrics(x)
+    tune::check_metric_in_tune_results(tibble::as_tibble(metrics), metric)
     opt_metric <- tune::first_metric(metrics)
     opt_metric_name <- opt_metric$metric
     if (metric[1] != opt_metric_name) {


### PR DESCRIPTION
Closes #89. :)

``` r
library(tidymodels)
library(censored)
#> Loading required package: survival
library(finetune)

data("mlc_churn")

mlc_churn <-
  mlc_churn %>%
  mutate(
    churned = ifelse(churn == "yes", 1, 0),
    event_time = survival::Surv(account_length, churned)
  ) %>%
  select(event_time, account_length, area_code, total_eve_calls)

set.seed(6941)
churn_rs <- vfold_cv(mlc_churn)

eval_times <- c(50, 100, 150)

churn_rec <-
  recipe(event_time ~ ., data = mlc_churn) %>%
  step_dummy(area_code) %>%
  step_normalize(all_predictors())

tree_spec <-
  decision_tree(cost_complexity = tune(), min_n = 2) %>%
  set_mode("censored regression")

stc_met <- metric_set(concordance_survival)

set.seed(22)
race_stc_res <- tree_spec %>%
  tune_race_anova(
    event_time ~ .,
    resamples = churn_rs,
    grid = tibble(cost_complexity = 10^c(-1.4, -2.5, -3, -5)),
    metrics = stc_met
  )

show_best(race_stc_res, metric = "brier_survival_integrated")
#> Error in `show_best()`:
#> ! "brier_survival_integrated" was not in the metric set. Please choose
#>   from: "concordance_survival".
#> Backtrace:
#>     ▆
#>  1. ├─tune::show_best(race_stc_res, metric = "brier_survival_integrated")
#>  2. └─finetune:::show_best.tune_race(race_stc_res, metric = "brier_survival_integrated")
#>  3.   └─tune::check_metric_in_tune_results(...)
#>  4.     └─cli::cli_abort(...)
#>  5.       └─rlang::abort(...)
```

<sup>Created on 2024-01-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>