### PR TITLE
Condition test on `kknn`

### DIFF
--- a/tests/testthat/test-race-s3.R
+++ b/tests/testthat/test-race-s3.R
@@ -2,6 +2,7 @@
 test_that("racing S3 methods", {
   skip_if_not_installed("Matrix", "1.6-2")
   skip_if_not_installed("lme4", "1.1-35.1")
+  skip_if_not_installed("kknn")
 
   library(purrr)
   library(dplyr)


### PR DESCRIPTION
The `test-race-s3.R` test sets `kknn` as the engine without checking for `kknn` availability (it is a Suggests dependency). This PR conditions the test on `kknn` being installed.

Error was originally encountered when running testthat tests during [Conda Forge package building](https://github.com/conda-forge/r-finetune-feedstock/pull/2), which does not default to installing Suggests packages in test phase.