### PR TITLE
work with null results when model fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # finetune (development version)
 
+* A bug was fixed where `NULL` results generated during simulated annealing would cause errors when logging. 
+
 # finetune 1.2.1
 
 * Maintenance release required by CRAN.

--- a/R/sim_anneal_helpers.R
+++ b/R/sim_anneal_helpers.R
@@ -459,31 +459,42 @@ get_outcome_names <- function(x, rs) {
   res
 }
 
+set_config <- function(x, config = NULL, prefix = NULL) {
+  if (!is.null(x)) {
+    if (!is.null(prefix)) {
+      x <- dplyr::mutate(x, .config = paste0(prefix, "_", .config))
+    } else {
+      x <- dplyr::mutate(x, .config = config)
+    }
+  }
+  x
+}
+
 update_config <- function(x, prefix = NULL, config = "new", save_pred) {
   if (!is.null(prefix)) {
     x$.metrics <-
       purrr::map(
         x$.metrics,
-        \(x) dplyr::mutate(x, .config = paste0(prefix, "_", .config))
+        \(x) set_config(x, prefix = prefix)
       )
     if (save_pred) {
       x$.predictions <-
         purrr::map(
           x$.predictions,
-          \(x) dplyr::mutate(x, .config = paste0(prefix, "_", .config))
+          \(x) set_config(x, prefix = prefix)
         )
     }
   } else {
     x$.metrics <-
       purrr::map(
         x$.metrics,
-        \(x) dplyr::mutate(x, .config = config)
+        \(x) set_config(x, config = config)
       )
     if (save_pred) {
       x$.predictions <-
         purrr::map(
           x$.predictions,
-          \(x) dplyr::mutate(x, .config = config)
+          \(x) set_config(x, config = config)
         )
     }
   }

--- a/tests/testthat/test-sa-misc.R
+++ b/tests/testthat/test-sa-misc.R
@@ -83,3 +83,26 @@ test_that("tune_sim_anneal with wrong type", {
     error = TRUE
   )
 })
+
+# ------------------------------------------------------------------------------
+
+test_that("tune_sim_anneal loggining doesn't error with failed model", {
+  # no failed results:
+  res_1 <- purrr::map_dfr(
+    ames_iter_search$.metrics,
+    finetune:::set_config,
+    config = "beratna"
+  )
+  expect_true(all(res_1$.config == "beratna"))
+
+  has_failure <- tune:::vec_list_rowwise(ames_iter_search$.metrics[[1]])[1:3]
+  has_failure[2] <- list(NULL)
+  res_2 <- purrr::map(
+    has_failure,
+    finetune:::set_config,
+    config = "sasa ke?"
+  )
+  expect_null(res_2[[2]])
+  expect_equal(res_2[[1]]$.config, "sasa ke?")
+  expect_equal(res_2[[3]]$.config, "sasa ke?")
+})


### PR DESCRIPTION
In some cases, the model may fail during an iteration of SA. This causes an error when we try to update the `.config` values of NULL. 